### PR TITLE
Fixed: portal/cli freezing due to buffer issue

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -67,8 +67,21 @@ def cli():
 
         def _exec(self, snippet):
             pid = Popen(snippet, shell=True, stdout=PIPE, stderr=PIPE)
-            pid.wait()
-            return pid.returncode, pid.stdout.read()
+
+            #
+            # - taken from ochopod's subprocess piping; avoids issues with buffering
+            #
+            outs = []
+
+            while True:
+
+                line = pid.stdout.readline().rstrip('\n')
+                code = pid.poll()
+                if line == '' and code is not None:
+                    break
+                outs += [line]
+
+            return pid.returncode, '\n'.join(outs)
 
     try:
         #

--- a/images/portal/resources/portal.py
+++ b/images/portal/resources/portal.py
@@ -76,9 +76,21 @@ if __name__ == '__main__':
                 # - wait for completion
                 # - return as json ('out' contains the verbatim dump from the sub-process stdout)
                 #
-                pid.wait()
+                outs = []
+
+                #
+                # - taken from ochopod's subprocess piping; avoids issues with buffering
+                #
+                while True:
+
+                    line = pid.stdout.readline().rstrip('\n')
+                    code = pid.poll()
+                    if line == '' and code is not None:
+                        break
+                    outs += [line]
+
                 ms = 1000 * (time.time() - ts)
-                return json.dumps({'ok': pid.returncode == 0, 'ms': int(ms), 'out': pid.stdout.read()})
+                return json.dumps({'ok': pid.returncode == 0, 'ms': int(ms), 'out': '\n'.join(outs)})
 
             except Exception as failure:
 
@@ -112,9 +124,21 @@ if __name__ == '__main__':
                 # - wait for completion
                 # - return as json ('out' contains the verbatim dump from the sub-process stdout)
                 #
-                pid.wait()
+                outs = []
+
+                #
+                # - taken from ochopod's subprocess piping; avoids issues with buffering
+                #
+                while True:
+
+                    line = pid.stdout.readline().rstrip('\n')
+                    code = pid.poll()
+                    if line == '' and code is not None:
+                        break
+                    outs += [line]
+
                 ms = 1000 * (time.time() - ts)
-                return json.dumps({'ok': pid.returncode == 0, 'ms': int(ms), 'out': pid.stdout.read()})
+                return json.dumps({'ok': pid.returncode == 0, 'ms': int(ms), 'out': '\n'.join(outs)})
 
             except Exception as failure:
 


### PR DESCRIPTION
Instead of waiting for a call to a tool with a lot of output, cli/portal now pipes STDOUT/ERR line-by-line.
