### PR TITLE
More options when working with override files

### DIFF
--- a/dcos.json
+++ b/dcos.json
@@ -6,12 +6,15 @@
     {
         "ochopod_cluster":  "portal",
         "ochopod_debug":    "true",
-        "ochopod_token":    ""
+        "ochopod_token":    "UPTOWN_GIRL"
     },
     "acceptedResourceRoles":
         [
             "slave_public"
         ],
+    "uris": [
+        "file:///home/core/docker.tar.gz"
+    ],
     "container":
     {
         "type":"DOCKER",
@@ -19,7 +22,7 @@
         {
             "forcePullImage":               true,
             "network":                      "BRIDGE",
-            "image":                        "autodeskcloud/ochothon:1.0.2",
+            "image":                        "gomesa/ochothon:1.0.2",
             "portMappings":
                 [
                     {

--- a/dcos.json
+++ b/dcos.json
@@ -6,15 +6,12 @@
     {
         "ochopod_cluster":  "portal",
         "ochopod_debug":    "true",
-        "ochopod_token":    "UPTOWN_GIRL"
+        "ochopod_token":    ""
     },
     "acceptedResourceRoles":
         [
             "slave_public"
         ],
-    "uris": [
-        "file:///home/core/docker.tar.gz"
-    ],
     "container":
     {
         "type":"DOCKER",
@@ -22,7 +19,7 @@
         {
             "forcePullImage":               true,
             "network":                      "BRIDGE",
-            "image":                        "gomesa/ochothon:1.0.2",
+            "image":                        "autodeskcloud/ochothon:1.0.2",
             "portMappings":
                 [
                     {

--- a/images/portal/resources/toolset/toolset/commands/deploy.py
+++ b/images/portal/resources/toolset/toolset/commands/deploy.py
@@ -21,6 +21,7 @@ import os
 import time
 import yaml
 
+from fnmatch import fnmatch
 from ochopod.core.fsm import diagnostic
 from ochopod.core.utils import merge, retry, shell
 from random import choice
@@ -29,7 +30,7 @@ from threading import Thread
 from toolset.io import fire, run
 from toolset.tool import Template
 from yaml import YAMLError
-import re
+
 
 #: Our ochopod logger.
 logger = logging.getLogger('ochopod')
@@ -118,7 +119,7 @@ class _Automation(Thread):
                 # - used for general properties
                 #
                 matches = [key for key, _ in self.overrides.iteritems()
-                           if key != qualified and re.search(key, qualified)]
+                           if key != qualified and fnmatch(qualified, key)]
                 blk = {}
                 if matches:
                     # iterate trough all the key matches merging the overrides


### PR DESCRIPTION
This will allow you to:
- Have multiple override files

Example:
hibernate.overrides.yml
secrets.overrides.yml.aes

All the overrides in the files are merged together.
If the same property is specified in more than one file, there's no guarantee which one will be used.

Use case:
hibernate.overrides.yml contains the url of the database
secrets.overrides.yml.aes contains the password of the database.

the url can easily be modified while the password is still protected.
- Use regexps in the override files:

Example:
dev.*:
  hibernate:
      connectionURL:  url

All pods under dev have the same hibernate connection URL without need for duplication.
