### PR TITLE
Allow to specify protocol (TCP or UDP) for port mappings.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Need to know on what port your containerized Zookeeper_ ensemble is listening on
     > port 2181 *zookeeper
     <*zookeeper> -> 100% replies (3 pods total) ->
 
-    cluster                  |  node IP         |  TCP
+    cluster                  |  node IP         |  port
                              |                  |
     my.project.zookeeper #1  |  54.81.20.224    |  9001
     my.project.zookeeper #2  |  54.198.16.240   |  1029

--- a/images/portal/resources/toolset/toolset/commands/port.py
+++ b/images/portal/resources/toolset/toolset/commands/port.py
@@ -29,7 +29,8 @@ def go():
 
         help = \
             '''
-                Displays the current remapping for a given TCP port across the specified cluster(s).
+                Displays the current remapping for a given port across the specified cluster(s). The current implementation
+                does not allow to indicate whether the protocol is TCP or UDP.
 
                 This tool supports optional output in JSON format for 3rd-party integration via the -j switch.
             '''
@@ -38,7 +39,7 @@ def go():
 
         def customize(self, parser):
 
-            parser.add_argument('port', type=int, nargs=1, help='TCP port to lookup')
+            parser.add_argument('port', type=int, nargs=1, help='port to lookup')
             parser.add_argument('clusters', type=str, nargs='?', default='*', help='cluster(s) (can be a glob pattern, e.g foo*)')
             parser.add_argument('-j', '--json', action='store_true', help='switch for json output')
 
@@ -62,7 +63,7 @@ def go():
                 # - justify & format the whole thing in a nice set of columns
                 #
                 logger.info('<%s> -> %d%% replies (%d pods total) ->\n' % (args.clusters, pct, len(js)))
-                rows = [['pod', '|', 'pod IP', '|', 'public IP', '|', 'TCP'], ['', '|', '', '|', '', '|', '']] + js
+                rows = [['pod', '|', 'pod IP', '|', 'public IP', '|', 'port'], ['', '|', '', '|', '', '|', '']] + js
                 widths = [max(map(len, col)) for col in zip(*rows)]
                 for row in rows:
                     logger.info('  '.join((val.ljust(width) for val, width in zip(row, widths))))


### PR DESCRIPTION
Salut Olivier,

As discussed yesterday, here is a small pull request to be able to specify the protocol for exposed ports.

As you will see, I also modified a couple of labels (e.g. when using the 'port' command) because it is actually not correct to say 'TCP'. For example, if you deploy a pod through the Marathon API and  maps some UDP ports, they would still be listed under the TCP column in Ochothon...this is misleading.

Of course, it would be nice to see whether the port is using TCP or UDP, but that would require extra work in Ochopod I think: Mesos/Marathon do not set any env variable to differentiate between TCP and UDP ports from what I have seen.

Cheers,
Patrice
