### PR TITLE
Fixed long wait bug when scaling up a cluster with the -g flag.

### DIFF
--- a/images/portal/resources/toolset/toolset/commands/scale.py
+++ b/images/portal/resources/toolset/toolset/commands/scale.py
@@ -133,10 +133,14 @@ class _Automation(Thread):
                 def _spin():
                     def _query(zk):
                         replies = fire(zk, self.cluster, 'info')
-                        return [seq for seq, _, _ in replies.values()]
+                        return [(seq, hints['application'], hints['task']) for (seq, hints, _) in replies.values()]
 
                     js = run(self.proxy, _query)
-                    assert len(js) == target, 'not all pods running yet'
+                    if self.group is not None:
+                        nb_pods = sum(1 for (_, key, _) in js if key == app)
+                    else:
+                        nb_pods = len(js)
+                    assert nb_pods == target, 'not all pods running yet'
                     return js
 
                 _spin()


### PR DESCRIPTION
When using the -g flag to scale up a cluster, the wait for all pods to
be up would never succeed and always reach the timeout when there is
more than one Marathon application with the same cluster name. Note that
this bug was actually not leading to an error since the _spin() would
return eventually (even if the condition is not met), but it would wait
for the duration of the specified timeout for nothing.
